### PR TITLE
made config overridable by param.config

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -31,12 +31,12 @@ function Adapter (params) {
         migrationTable: "_migrations"
     };
 
-    if (this.params.config && this.params.config.migrationTable) {
-        this.config.migrationTable = this.params.config.migrationTable;
+    if (this.params.eastMysql && this.params.eastMysql.migrationTable) {
+        this.config.migrationTable = this.params.eastMysql.migrationTable;
     }
 
-    if (this.params.config && this.params.config.migrationFile) {
-        this.config.migrationFile = this.params.config.migrationFile;
+    if (this.params.eastMysql && this.params.eastMysql.migrationFile) {
+        this.config.migrationFile = this.params.eastMysql.migrationFile;
     }
 
 }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -31,6 +31,14 @@ function Adapter (params) {
         migrationTable: "_migrations"
     };
 
+    if (this.params.config && this.params.config.migrationTable) {
+        this.config.migrationTable = this.params.config.migrationTable;
+    }
+
+    if (this.params.config && this.params.config.migrationFile) {
+        this.config.migrationFile = this.params.config.migrationFile;
+    }
+
 }
 
 

--- a/test/unit/adapter.test.js
+++ b/test/unit/adapter.test.js
@@ -84,7 +84,7 @@ describe("adapter test", function () {
 
             var obj = new Adapter({
                 url: "some url",
-                config: {
+                eastMysql: {
                     migrationFile: 'overrideMigrateTemplate.js',
                     migrationTable: '_override'
                 }

--- a/test/unit/adapter.test.js
+++ b/test/unit/adapter.test.js
@@ -80,6 +80,24 @@ describe("adapter test", function () {
 
         });
 
+        it("should override the config with params.config", function () {
+
+            var obj = new Adapter({
+                url: "some url",
+                config: {
+                    migrationFile: 'overrideMigrateTemplate.js',
+                    migrationTable: '_override'
+                }
+            });
+
+            expect(obj.config).to.be.an("object")
+                .to.be.eql({
+                migrationFile: "overrideMigrateTemplate.js",
+                migrationTable: "_override"
+            });
+
+        });
+
     });
 
 


### PR DESCRIPTION
Hey @riggerthegeek! First, thanks for contributing this package to the OSC! 

In our usage we wanted to be able to specify what table is used to store the migrations. This pull request makes overriding the template and table name possible by providing config value in the constructor params.


```js
var obj = new Adapter({
                 url: "some url",
                 eastMysql: {
                     migrationFile: 'overrideMigrateTemplate.js',
                     migrationTable: '_override'
                 }
             });
```

